### PR TITLE
workaround for tsym::sqrt()/sqrt() issue

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -196,7 +196,7 @@ libEnv.CFile(parser, 'src/parser.y')
 testEnv.VariantDir(testEnv.buildDir(), 'test')
 testEnv.Append(CPPPATH = [libEnv.buildDir(), testEnv.buildDir()])
 if not testEnv.concat('LIBS'):
-    testEnv.Append(LIBS = ['CppUTest', 'tsym', 'plic', 'gmp', 'python3.6m'])
+    testEnv.Append(LIBS = ['CppUTest', 'tsym', 'plic', 'gmp', 'python3.5m'])
 testEnv.Append(RPATH = env.buildDir())
 testEnv.Append(LIBPATH = env.buildDir())
 

--- a/test/testvar.cpp
+++ b/test/testvar.cpp
@@ -39,9 +39,9 @@ TEST_GROUP(Var)
         one = Var(1);
         two = Var(2);
         three = Var(3);
-        sqrtTwo = sqrt(2);
-        sqrtThree = sqrt(3);
-        sqrtSix = sqrt(6);
+        sqrtTwo = tsym::sqrt(2);
+        sqrtThree = tsym::sqrt(3);
+        sqrtSix = tsym::sqrt(6);
     }
 };
 
@@ -683,10 +683,10 @@ TEST(Var, orderingOfProductOfConstants)
 TEST(Var, constProductsEqualBaseAfterExtraction)
     /* 17^(2/3)*sqrt(833) = 7*17^(1/6). */
 {
-    const Var expected(119*pow(17, Var(1, 6)));
+    const Var expected(119*tsym::pow(17, Var(1, 6)));
     Var res;
 
-    res = pow(17, Var(2, 3))*sqrt(833);
+    res = tsym::pow(17, Var(2, 3))*tsym::sqrt(833);
 
     CHECK_EQUAL(expected, res);
 }
@@ -695,12 +695,12 @@ TEST(Var, orderingOfLargeProductOfConstants)
     /* 5*(2/9)*sqrt(3)*2^(1/5)*sqrt(17)*(10/11)*sqrt(2)*sqrt(7)*4^(1/5)*17^(2/3)*(1/4)*sqrt(7) =
      * 25/33*2^(3/5)*17^(2/3)*sqrt(1666/3). */
 {
-    const Var expected(Var(25, 33)*pow(2, Var(3, 5))*pow(17, Var(2, 3))*sqrt(Var(1666, 3)));
+    const Var expected(Var(25, 33)*tsym::pow(2, Var(3, 5))*tsym::pow(17, Var(2, 3))*tsym::sqrt(Var(1666, 3)));
     Var res;
 
-    res = 5*Var(2, 9)*sqrt(3)*pow(2, Var(1, 5))*sqrt(17)*Var(10, 11)
-        *sqrt(2)*sqrt(7)*pow(4, Var(1, 5))*pow(17, Var(2, 3))*Var(1, 4)
-        *sqrt(7);
+    res = 5*Var(2, 9)*tsym::sqrt(3)*tsym::pow(2, Var(1, 5))*tsym::sqrt(17)*Var(10, 11)
+        *tsym::sqrt(2)*tsym::sqrt(7)*pow(4, Var(1, 5))*tsym::pow(17, Var(2, 3))*Var(1, 4)
+        *tsym::sqrt(7);
 
     CHECK_EQUAL(expected, res);
 }
@@ -766,7 +766,7 @@ TEST(Var, expandProductOfConstTerms)
     res = (1 + 2*sqrtTwo*sqrtThree)*a + (2 + sqrtTwo*sqrtThree)*a;
 
     CHECK_EQUAL(Var::Type::SUM, res.type());
-    CHECK_EQUAL(3*a + 3*sqrt(6)*a, res);
+    CHECK_EQUAL(3*a + 3*tsym::sqrt(6)*a, res);
 }
 
 TEST(Var, simpleExpansion)
@@ -784,8 +784,8 @@ TEST(Var, simpleExpansion)
 TEST(Var, dontCollectProductOfConstTerms)
     /* 2*sqrt(3)*sqrt(2) + 3*sqrt(3)*sqrt(5) = 2*sqrt(6) + 3*sqrt(15). */
 {
-    const Var sqrtFive(sqrt(5));
-    const Var sqrtFifteen(sqrt(15));
+    const Var sqrtFive(tsym::sqrt(5));
+    const Var sqrtFifteen(tsym::sqrt(15));
     Var res;
 
     res = 2*sqrtThree*sqrtTwo + 3*sqrtThree*sqrtFive;
@@ -870,11 +870,11 @@ TEST(Var, largeMixedTerm01)
     /* a + 2*sqrt(2)*b + 3*c - 7*a*sqrt(2)*sqrt(3)*5^(1/3) + 4*d^(2*b + 2*a) - b*2/sqrt(2) -
      * b*sqrt(2) = (1 - 7*5^(1/3)*sqrt(6))*a + 3*c + 4*d^(2*a + 2*b). */
 {
-    const Var expected((1 - 7*pow(5, Var(1, 3))*sqrt(6))*a + 3*c + 4*pow(d, 2*a + 2*b));
+    const Var expected((1 - 7*tsym::pow(5, Var(1, 3))*tsym::sqrt(6))*a + 3*c + 4*tsym::pow(d, 2*a + 2*b));
     Var res;
 
-    res = a + 2*sqrt(2)*b + 3*c - 7*a*sqrt(2)*sqrt(3)*pow(5, Var(1, 3)) + 4*pow(d, 2*b + 2*a) -
-        b*2/sqrt(2) - b*sqrt(2);
+    res = a + 2*tsym::sqrt(2)*b + 3*c - 7*a*tsym::sqrt(2)*tsym::sqrt(3)*tsym::pow(5, Var(1, 3)) + 4*tsym::pow(d, 2*b + 2*a) -
+        b*2/tsym::sqrt(2) - b*tsym::sqrt(2);
 
     CHECK_EQUAL(expected, res);
 }
@@ -883,11 +883,11 @@ TEST(Var, largeMixedTerm02)
     /* 2^(1/3)*(a + b)*2^(1/4)*sqrt(2) + (b + a)*2^(1/12) + (a + b)*(d + c) = 3*2^(1/12)*a +
      * 3*2^(1/12)*b + (a + b)*(d + c). */
 {
-    const Var fac(3*pow(2, Var(1, 12)));
+    const Var fac(3*tsym::pow(2, Var(1, 12)));
     const Var expected(fac*a + fac*b + (a + b)*(c + d));
     Var res;
 
-    res = pow(2, Var(1, 3))*(a + b)*pow(2, Var(1, 4))*sqrt(2) + (b + a)*pow(2, Var(1, 12))
+    res = tsym::pow(2, Var(1, 3))*(a + b)*tsym::pow(2, Var(1, 4))*tsym::sqrt(2) + (b + a)*tsym::pow(2, Var(1, 12))
         + (a + b)*(d + c);
 
     CHECK_EQUAL(expected, res);
@@ -906,10 +906,10 @@ TEST(Var, largeMixedTerm03)
 
 TEST(Var, largeMixedTerm04)
 {
-    const Var expected((10 + sqrtTwo)*a + 100*pow(a, 2) + (3 + sqrtTwo)*b + 2*c + Var(13, 9)*d);
+    const Var expected((10 + sqrtTwo)*a + 100*tsym::pow(a, 2) + (3 + sqrtTwo)*b + 2*c + Var(13, 9)*d);
     Var res;
 
-    res = (a + 2*b + 2*c) + (9*a + b + d) + sqrt(2)*(a + b) + 4*d/9 + 100*a*a;
+    res = (a + 2*b + 2*c) + (9*a + b + d) + tsym::sqrt(2)*(a + b) + 4*d/9 + 100*a*a;
 
     CHECK_EQUAL(expected, res);
 }
@@ -918,11 +918,11 @@ TEST(Var, largeMixedTerm05)
     /* a^(2/3)*e*sqrt(2)*sqrt(3)*b*2*d*e*(e + 2)*a*c*sqrt(3)*a^(1/5)*sqrt(5)*sqrt(3) =
      * 6*sqrt(30)*a^(28/15)*b*c*d*e^2*(2 + e). */
 {
-    const Var expected(6*sqrt(30)*pow(a, Var(28, 15))*b*c*d*pow(e, 2)*(2 + e));
+    const Var expected(6*tsym::sqrt(30)*tsym::pow(a, Var(28, 15))*b*c*d*tsym::pow(e, 2)*(2 + e));
     Var res;
 
-    res = pow(a, Var(2, 3))*e*sqrt(2)*sqrt(3)*b*2*d*e*(e + 2)*a*c*sqrt(3)*pow(a, Var(1, 5))
-        *sqrt(5)*sqrt(3);
+    res = tsym::pow(a, Var(2, 3))*e*tsym::sqrt(2)*tsym::sqrt(3)*b*2*d*e*(e + 2)*a*c*tsym::sqrt(3)*tsym::pow(a, Var(1, 5))
+        *tsym::sqrt(5)*tsym::sqrt(3);
 
     CHECK_EQUAL(expected, res);
     CHECK_EQUAL(8, res.operands().size());


### PR DESCRIPTION
muss ich das jetrzt auch noch mit schieben. auch wenn das eig ja im anderen schon mit drin wäre?