### PR TITLE
Changing matrix solver pivot element complexity

### DIFF
--- a/src/base.h
+++ b/src/base.h
@@ -36,6 +36,7 @@ namespace tsym {
             /* If unclear or zero, the following two methods shall return false: */
             virtual bool isPositive() const = 0;
             virtual bool isNegative() const = 0;
+            virtual unsigned complexity() const = 0;
             virtual size_t hash() const = 0;
 
             virtual bool isZero() const;
@@ -70,6 +71,7 @@ namespace tsym {
             /* These two methods return clone() and 1 and must be overridden by Power only. */
             virtual BasePtr base() const;
             virtual BasePtr exp() const;
+
             /* Returns Symbol/Constant/Function name, an empty Name otherwise: */
             virtual const Name& name() const;
 

--- a/src/baseptrlist.cpp
+++ b/src/baseptrlist.cpp
@@ -274,6 +274,15 @@ tsym::BasePtrList tsym::BasePtrList::getNonConstElements() const
 
     return items;
 }
+unsigned tsym::BasePtrList::getComplexitySum() const
+{
+    unsigned complexitySum = 0;
+
+    for (const auto& item : list)
+        complexitySum += item->complexity();
+
+    return complexitySum;
+}
 
 tsym::BasePtr tsym::BasePtrList::expandAsProduct() const
 {

--- a/src/baseptrlist.h
+++ b/src/baseptrlist.h
@@ -66,6 +66,7 @@ namespace tsym {
             bool hasSumElements() const;
             bool areElementsNumericallyEvaluable() const;
             bool areAllElementsConst() const;
+            unsigned getComplexitySum() const;
             /* Here, the Constant class is treated as a variable, only Numerics and a numeric Power
              * are considered as constant items. */
             BasePtrList getConstElements() const;

--- a/src/constant.cpp
+++ b/src/constant.cpp
@@ -82,6 +82,11 @@ size_t tsym::Constant::hash() const
     return std::hash<EnumType>{}(static_cast<EnumType>(type));
 }
 
+unsigned tsym::Constant::complexity() const
+{
+    return 4;
+}
+
 bool tsym::Constant::isNumericallyEvaluable() const
 {
     return true;

--- a/src/constant.h
+++ b/src/constant.h
@@ -20,6 +20,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Overridden methods from Base. */

--- a/src/function.h
+++ b/src/function.h
@@ -16,6 +16,7 @@ namespace tsym {
             virtual BasePtr subst(const BasePtr& from, const BasePtr& to) const = 0;
             virtual bool isPositive() const = 0;
             virtual bool isNegative() const = 0;
+            virtual unsigned complexity() const = 0;
 
             /* Implentations of pure virtual methods of Base. */
             bool isEqualDifferentBase(const BasePtr& other) const;

--- a/src/logarithm.cpp
+++ b/src/logarithm.cpp
@@ -146,3 +146,8 @@ bool tsym::Logarithm::isNegative() const
 {
     return checkSign(&Base::isNegative);
 }
+
+unsigned tsym::Logarithm::complexity() const
+{
+    return 6 + arg->complexity();
+}

--- a/src/logarithm.h
+++ b/src/logarithm.h
@@ -16,6 +16,7 @@ namespace tsym {
             BasePtr subst(const BasePtr& from, const BasePtr& to) const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
 
         private:
             Logarithm(const BasePtr& arg);

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -311,10 +311,8 @@ tsym::Vector tsym::Matrix::solveChecked(const Vector& rhs) const
     Matrix PLU(*this);
     Vector b(rhs);
     Vector x(nRow);
-
     PLU.compPartialPivots(&b);
     PLU.factorizeLU();
-
     if (PLU.detFromLU().isZero()) {
         TSYM_WARNING("Can't solve system of equations with singular coefficient matrix!");
         x = Vector();
@@ -334,16 +332,28 @@ tsym::Vector tsym::Matrix::solveChecked(const Vector& rhs) const
 void tsym::Matrix::compPartialPivots(Vector *b)
 {
     for (size_t j = 0; j + 1 < nCol; ++j) {
-        if (!data[j][j].isZero())
-            continue;
-
-        for (size_t i = j + 1; i < nRow; ++i)
-            if (!data[i][j].isZero()) {
-                swapRows(i, j);
-                if (b != nullptr)
-                    std::swap(b->data[j], b->data[i]);
-                break;
+        size_t highestcomplpos = 0;
+        unsigned highestcompl = data[j][j].getBasePtr()->complexity();
+        for (size_t i = j + 1; i < nRow; ++i){
+            unsigned curr_complexity = data[i][j].getBasePtr()->complexity();
+            if (curr_complexity>highestcompl){
+                highestcompl=curr_complexity;
+                highestcomplpos = i;
             }
+        }
+        if(highestcompl > data[j][j].getBasePtr()->complexity()){
+            swapRows(highestcomplpos, j);
+            if (b != nullptr)
+                std::swap(b->data[j], b->data[highestcomplpos]);
+        }
+        if(data[j][j].isZero())
+            for (size_t i = j + 1; i < nRow; ++i)
+                if (!data[i][j].isZero()){
+                    swapRows(i, j);
+                    if (b != nullptr)
+                        std::swap(b->data[j], b->data[i]);
+                    break;
+                }
     }
 }
 
@@ -351,12 +361,13 @@ void tsym::Matrix::swapRows(size_t index1, size_t index2)
 {
     for (size_t j = 0; j < nCol; ++j)
         std::swap(data[index1][j], data[index2][j]);
+    swapEven = !swapEven;
 }
 
 void tsym::Matrix::factorizeLU()
 {
-    for (size_t j = 0; j + 1 < nCol; ++j) {
-        for (size_t i = j + 1; i < nRow; ++i) {
+    for (size_t j = 0; j + 1 < nCol; ++j){
+        for (size_t i = j + 1; i < nRow; ++i){
             data[i][j] /= data[j][j];
                 for (size_t k = j + 1; k < nCol; ++k)
                     data[i][k] -= data[i][j]*data[j][k];
@@ -430,7 +441,6 @@ tsym::Var tsym::Matrix::checkedDet() const
 
     PLU.compPartialPivots(nullptr);
     PLU.factorizeLU();
-
     return PLU.detFromLU();
 }
 
@@ -440,9 +450,9 @@ tsym::Var tsym::Matrix::detFromLU() const
 
     for (size_t i = 0; i < nRow; ++i)
         det *= data[i][i];
-
+    if(swapEven==false)
+        det *= -1;
     det = det.normal();
-
     return det;
 }
 

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -332,10 +332,10 @@ tsym::Vector tsym::Matrix::solveChecked(const Vector& rhs) const
 
 void tsym::Matrix::compPartialPivots(Vector *b)
 {
-    for (size_t j = 0; j + 1 < nCol; ++j){
+    for (size_t j = 0; j+1  < nCol; ++j){
         size_t highestcomplpos = 0;
         unsigned highestcompl = data[j][j].getBasePtr()->complexity();
-        for (size_t i = j + 1; i < nRow; ++i){
+        for (size_t i = j+1 ; i < nRow; ++i){
             unsigned curr_complexity = data[i][j].getBasePtr()->complexity();
             if (curr_complexity>highestcompl){
                 highestcompl=curr_complexity;

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -313,6 +313,7 @@ tsym::Vector tsym::Matrix::solveChecked(const Vector& rhs) const
     Vector x(nRow);
     PLU.compPartialPivots(&b);
     PLU.factorizeLU();
+
     if (PLU.detFromLU().isZero()) {
         TSYM_WARNING("Can't solve system of equations with singular coefficient matrix!");
         x = Vector();
@@ -331,7 +332,7 @@ tsym::Vector tsym::Matrix::solveChecked(const Vector& rhs) const
 
 void tsym::Matrix::compPartialPivots(Vector *b)
 {
-    for (size_t j = 0; j + 1 < nCol; ++j) {
+    for (size_t j = 0; j + 1 < nCol; ++j){
         size_t highestcomplpos = 0;
         unsigned highestcompl = data[j][j].getBasePtr()->complexity();
         for (size_t i = j + 1; i < nRow; ++i){
@@ -439,8 +440,11 @@ tsym::Var tsym::Matrix::checkedDet() const
 {
     Matrix PLU(*this);
 
+    std::cout<<"Inside Before: "<< PLU << std::endl;
     PLU.compPartialPivots(nullptr);
+    std::cout<<"Inside Middle: "<< PLU << std::endl;
     PLU.factorizeLU();
+    std::cout<<"Inside After: "<< PLU << std::endl;
     return PLU.detFromLU();
 }
 

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -58,6 +58,7 @@ namespace tsym {
             Var **data;
             size_t nRow;
             size_t nCol;
+            bool swapEven = true;
     };
 
     bool operator == (const Matrix& lhs, const Matrix& rhs);

--- a/src/numeric.cpp
+++ b/src/numeric.cpp
@@ -115,6 +115,19 @@ size_t tsym::Numeric::hash() const
     return std::hash<Number>{}(number);
 }
 
+unsigned tsym::Numeric::complexity() const
+{
+    /* A numeric object must not be instantiated from an undefined Number in the first place: */
+    assert(!number.isUndefined());
+
+    if (number.isInt())
+        return 1;
+    else if(number.isFrac())
+        return 2;
+    else
+        return 3;
+}
+
 bool tsym::Numeric::isNumericallyEvaluable() const
 {
     return true;

--- a/src/numeric.h
+++ b/src/numeric.h
@@ -28,6 +28,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Overridden methods from Base. */

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -150,6 +150,11 @@ size_t tsym::Power::hash() const
     return std::hash<BasePtrList>{}(ops);
 }
 
+unsigned tsym::Power::complexity() const
+{
+    return 5 + baseRef->complexity() + 2*expRef->complexity();
+}
+
 bool tsym::Power::isExponentRationalNumeric() const
 {
     return expRef->isNumericallyEvaluable() && expRef->numericEval().isRational();

--- a/src/power.h
+++ b/src/power.h
@@ -24,6 +24,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Overridden methods from Base. */

--- a/src/product.cpp
+++ b/src/product.cpp
@@ -186,6 +186,11 @@ size_t tsym::Product::hash() const
     return std::hash<BasePtrList>{}(ops);
 }
 
+unsigned tsym::Product::complexity() const
+{
+    return 5 + ops.getComplexitySum();
+}
+
 int tsym::Product::sign() const
 {
     int result = 1;

--- a/src/product.h
+++ b/src/product.h
@@ -26,6 +26,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Overridden methods from Base. */

--- a/src/sum.cpp
+++ b/src/sum.cpp
@@ -152,6 +152,11 @@ size_t tsym::Sum::hash() const
     return std::hash<BasePtrList>{}(ops);
 }
 
+unsigned tsym::Sum::complexity() const
+{
+    return 5 + ops.getComplexitySum();
+}
+
 int tsym::Sum::sign() const
 {
     const int numericSign = signOfNumericParts();

--- a/src/sum.h
+++ b/src/sum.h
@@ -23,6 +23,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Overridden methods from Base. */

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -129,6 +129,11 @@ size_t tsym::Symbol::hash() const
     return nameHash ^ (signHash << 1);
 }
 
+unsigned tsym::Symbol::complexity() const
+{
+    return 5;
+}
+
 bool tsym::Symbol::isSymbol() const
 {
     return true;

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -23,6 +23,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Overridden methods from Base. */

--- a/src/trigonometric.cpp
+++ b/src/trigonometric.cpp
@@ -396,6 +396,12 @@ tsym::Number tsym::Trigonometric::numericEval() const
         return checkedNumericEval();
 }
 
+unsigned tsym::Trigonometric::complexity() const
+{
+
+    return 6 + ops.getComplexitySum();
+}
+
 tsym::Number tsym::Trigonometric::checkedNumericEval() const
 {
     double (*fct)(double) = nullptr;

--- a/src/trigonometric.h
+++ b/src/trigonometric.h
@@ -31,6 +31,7 @@ namespace tsym {
             BasePtr subst(const BasePtr& from, const BasePtr& to) const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
 
         private:
             Trigonometric(const BasePtrList& args, Type type);

--- a/src/undefined.cpp
+++ b/src/undefined.cpp
@@ -101,3 +101,8 @@ int tsym::Undefined::degree(const BasePtr&) const
 {
     return 0;
 }
+
+unsigned tsym::Undefined::complexity() const
+{
+    return 0;
+}

--- a/src/undefined.h
+++ b/src/undefined.h
@@ -18,6 +18,7 @@ namespace tsym {
             std::string typeStr() const;
             bool isPositive() const;
             bool isNegative() const;
+            unsigned complexity() const;
             size_t hash() const;
 
             /* Returns always true: */

--- a/test/testcomplexity.cpp
+++ b/test/testcomplexity.cpp
@@ -1,0 +1,120 @@
+
+#include "abc.h"
+#include "constant.h"
+#include "power.h"
+#include "sum.h"
+#include "product.h"
+#include "trigonometric.h"
+#include "tsymtests.h"
+#include "undefined.h"
+#include "logarithm.h"
+
+using namespace tsym;
+
+TEST_GROUP(Complexity)
+{
+    BasePtr undef;
+    BasePtr integer;
+    BasePtr fraction;
+    BasePtr doubleval;
+    BasePtr constant;
+    BasePtr symbol;
+    BasePtr sum;
+    BasePtr prod;
+    BasePtr power;
+    BasePtr sinus;
+    BasePtr ln;
+    BasePtr undefnumeric;
+    void setup()
+    {
+        double a =2.7665454894445454;
+        undef = Undefined::create();
+        integer = Numeric::create(3);
+        fraction = Numeric::create(2,3);
+        doubleval= Numeric::create(a);
+        constant = Constant::createPi();
+        symbol = Symbol::create("a");
+        sum = Sum::create(integer,symbol);
+        prod = Product::create(integer,symbol,constant);
+        power = Power::create(integer,symbol);
+        sinus = Trigonometric::createSin(symbol);
+        ln = Logarithm::create(symbol);
+    }
+};
+
+TEST(Complexity, Undefined)
+{
+    unsigned res = undef->complexity();
+    CHECK_EQUAL(0,res);
+}
+
+TEST(Complexity, Integer)
+{
+    unsigned res = integer->complexity();
+    CHECK_EQUAL(1,res);
+}
+
+TEST(Complexity, Fraction)
+{
+    unsigned res = fraction->complexity();
+    CHECK_EQUAL(2,res);
+}
+
+TEST(Complexity, Double)
+{
+    unsigned res = doubleval->complexity();
+    CHECK_EQUAL(3,res);
+}
+
+TEST(Complexity, Constant)
+{
+    unsigned res = constant->complexity();
+    CHECK_EQUAL(4,res);
+}
+
+TEST(Complexity, Symbol)
+{
+    unsigned res = symbol->complexity();
+    CHECK_EQUAL(5, res);
+}
+
+TEST(Complexity, Sum)
+{
+    unsigned res = sum->complexity();
+    CHECK_EQUAL(5 + 1 + 5,res );
+}
+
+TEST(Complexity, Product)
+{
+    unsigned res = prod->complexity();
+    CHECK_EQUAL(5 + 1 + 5 + 4,res );
+}
+
+TEST(Complexity, Power)
+{
+    unsigned res = power->complexity();
+    CHECK_EQUAL(5 + 1 + 2*5,res );
+}
+
+TEST(Complexity, Trigonometric)
+{
+    unsigned res = sinus->complexity();
+    CHECK_EQUAL(6 + 5,res );
+}
+
+TEST(Complexity, Logarithm)
+{
+    unsigned res = ln->complexity();
+    CHECK_EQUAL(6 + 5,res );
+}
+
+TEST(Complexity, Largeterm)
+{
+    BasePtr symbol2 = Symbol::create("b");
+    unsigned expected = 5 + 15 + 5 + 3 + 11 + 16 + 11 + 4;
+    std::initializer_list<BasePtr> list = {prod,symbol2,doubleval,sinus,power,ln,constant};
+    BasePtrList largetermlist(list);
+    BasePtr largeterm = Sum::create(largetermlist);
+    unsigned res = largeterm->complexity();
+    CHECK_EQUAL(expected,res );
+}

--- a/test/testmatrix.cpp
+++ b/test/testmatrix.cpp
@@ -537,9 +537,38 @@ TEST(Matrix, luDecompPivoting)
     x = A.solve(rhs);
 
     CHECK_EQUAL((4*c - 3*b)/(a*c), x(0));
-    CHECK_EQUAL(3*(b - c)/c, x(1));
+    CHECK_EQUAL(-(3*(-b + c)/c), x(1));
     CHECK_EQUAL(3/c, x(2));
     CHECK_EQUAL((2*c + 3*b*c - 4*c*a*a - 3*b*b + 3*a*a*b)/(2*c), x(3));
+}
+
+TEST(Matrix, checkPivotElementComplexity)
+{
+    Matrix A(4, 4);
+    Vector rhs(4);
+    Vector x;
+
+    A(0, 0) = 3;
+    A(0, 1) = 1;
+    A(1, 1) = 6;
+    A(1, 0) = pow(a, 3);
+    A(1, 3) = 2;
+    A(2, 2) = 8;
+    A(2, 2) = 7;
+    A(2, 1) = 13*a;
+    A(1, 2) = b;
+    A(3, 2) = b;
+
+    rhs(0) = 1;
+    rhs(1) = 2;
+    rhs(2) = 3;
+    rhs(3) = 4;
+
+    x=A.solve(rhs);
+
+    //CHECK_EQUAL(pow(a, 3),A(0,0));
+    //not testable because pivoting is private
+    //and not possible to see from here
 }
 
 TEST(Matrix, linearEqSetDim2)

--- a/test/testmatrix.cpp
+++ b/test/testmatrix.cpp
@@ -682,15 +682,16 @@ TEST(Matrix, illegalLinearEqSetZeroDimension)
 
 TEST(Matrix, simpleSymbolDet)
 {
-    const Var expected(a*d - b*c);
+    const Var expected(a*0 - b*c);
     Matrix A(2, 2);
 
     A(0, 0) = a;
     A(0, 1) = b;
     A(1, 0) = c;
-    A(1, 1) = d;
-
+    A(1, 1) = 0;
+    std::cout<<"Before: "<< A << std::endl;
     CHECK_EQUAL(expected, A.det());
+    std::cout<<"After: "<< A << std::endl;
 }
 
 TEST(Matrix, largeNumericDet)

--- a/test/testmatrix.cpp
+++ b/test/testmatrix.cpp
@@ -682,13 +682,13 @@ TEST(Matrix, illegalLinearEqSetZeroDimension)
 
 TEST(Matrix, simpleSymbolDet)
 {
-    const Var expected(a*0 - b*c);
+    const Var expected(0*d - b*c);
     Matrix A(2, 2);
 
-    A(0, 0) = a;
+    A(0, 0) = 0;
     A(0, 1) = b;
     A(1, 0) = c;
-    A(1, 1) = 0;
+    A(1, 1) = d;
     std::cout<<"Before: "<< A << std::endl;
     CHECK_EQUAL(expected, A.det());
     std::cout<<"After: "<< A << std::endl;


### PR DESCRIPTION
This branch already has the complexity base method but is still missing the sqrt()/tsym::sqrt() fix